### PR TITLE
Changed queue file delete point

### DIFF
--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -103,7 +103,6 @@ class Crawler:
     startTime = time.time()
     for i in range(0, iterations):
       self.queue = FileIO.fileToSet(self.queueFile)
-      FileIO.deleteFileContents(self.queueFile)
       self.crawled = FileIO.fileToSet(self.crawledFile)
 
       newLinks = set()
@@ -115,6 +114,7 @@ class Crawler:
         newCrawledLinks.add(nextLink)
         newLinks = newLinks.union(res)
 
+      FileIO.deleteFileContents(self.queueFile)
       FileIO.setToFile(newLinks, self.queueFile)
       FileIO.setToFile(newCrawledLinks, self.crawledFile)
 


### PR DESCRIPTION
**Updates**
1. Queue delete point is now right before writing new queue. This is done so that we can recover quicker if a crash happens.

**Testing Plan**
Run crawler, see that it still works.
