### PR TITLE
Remove Manually Assigned DocID from Crawler Object and Make necessary dependency adjustments

### DIFF
--- a/client/frontend/src/SearchResult/Results.js
+++ b/client/frontend/src/SearchResult/Results.js
@@ -32,7 +32,6 @@ function Results(props: Props) {
           title="Google - Images"
           sampleText="Hello i am random sample text for google. This is text related to what you
         have searched for. Blah blah blah here is some more text."
-          docId={'32'}
           likes={69420}
           likeStatus={0}
           key={i}
@@ -49,9 +48,8 @@ function Results(props: Props) {
       console.log(document);
       output.push(
         <SingleResult
-          url={document['url']}
+          url={document['_id']}
           title={document['title']}
-          docId={document['_id']}
           likeStatus={0}
           likes={0}
           key={document['_id']}

--- a/client/frontend/src/SearchResult/SearchResult.js
+++ b/client/frontend/src/SearchResult/SearchResult.js
@@ -61,8 +61,6 @@ function SearchResult(props) {
     const { data } = await axios.get(`/search/${oldQuery}`);
     const docUrls = data['content']['sortedDocUrls'];
     updateNumSearched(docUrls.length);
-    // const docIdList = data['content']['sortedDocIds'];
-    // updateNumSearched(docIdList.length);
     fetchDocuments(docUrls).then(() => {
       changeSearchTime((Date.now() - startTime) / 1000);
       changeLoading(false);

--- a/client/frontend/src/SearchResult/SearchResult.js
+++ b/client/frontend/src/SearchResult/SearchResult.js
@@ -59,16 +59,18 @@ function SearchResult(props) {
   async function fetchQueryResults() {
     const startTime = Date.now();
     const { data } = await axios.get(`/search/${oldQuery}`);
-    const docIdList = data['content']['sortedDocIds'];
-    updateNumSearched(docIdList.length);
-    fetchDocuments(docIdList).then(() => {
+    const docUrls = data['content']['sortedDocUrls'];
+    updateNumSearched(docUrls.length);
+    // const docIdList = data['content']['sortedDocIds'];
+    // updateNumSearched(docIdList.length);
+    fetchDocuments(docUrls).then(() => {
       changeSearchTime((Date.now() - startTime) / 1000);
       changeLoading(false);
     });
   }
 
-  async function fetchDocuments(docIdList) {
-    const { data } = await axios.post('/fetchDocuments', { docIds: docIdList });
+  async function fetchDocuments(docUrls) {
+    const { data } = await axios.post('/fetchDocuments', { docUrls: docUrls });
     changeDocuments(data['content']['documents']);
   }
 

--- a/client/frontend/src/SearchResult/SingleResult.js
+++ b/client/frontend/src/SearchResult/SingleResult.js
@@ -42,7 +42,6 @@ const useStyles = makeStyles((theme) => ({
 
 type Props = {
   url: string,
-  docId: string,
   title: string,
   sampleText: string,
   likes: number,
@@ -56,11 +55,11 @@ export default function SingleResult(props: Props) {
   const maxLength = 170;
 
   function likePressed() {
-    console.log(`Like button pressed for doc #${props.docId}`);
+    console.log(`Like button pressed for doc #${props.url}`);
   }
 
   function dislikePressed() {
-    console.log(`Dislike button pressed for #${props.docId}`);
+    console.log(`Dislike button pressed for #${props.url}`);
   }
 
   function changeUrl() {

--- a/client/server.js
+++ b/client/server.js
@@ -68,8 +68,8 @@ app.get('/checkAuthenticated', (req, res) => {
 app.post('/fetchDocuments', async (req, res) => {
   const startTime = Date.now()
   log('fetch', 'Fetching documents from ranker')
-  const docIds = req.body['docIds'].slice(0, 60)
-  const data = await makeRequest('ranker', 'fetchDocuments', 'POST', {docIds: docIds})
+  const docUrls = req.body['docUrls'].slice(0, 60)
+  const data = await makeRequest('ranker', 'fetchDocuments', 'POST', {docUrls: docUrls})
   const documents = data['content']['documents']
   log('fetch', `Received documents from ranker. Execution time ${(Date.now() - startTime) / 1000} seconds.`)
   return res.json(sendPacket(1, 'Successfully fetched documents', {documents: documents}))

--- a/crawler/calculateTFIDF.py
+++ b/crawler/calculateTFIDF.py
@@ -23,8 +23,8 @@ def calculateTFIDF():
             if (tf != 0):
                 log_tf = math.log(tf, 2) + 1
             tf_idf = log_tf * idf
-            docNum = int(termEntry['doc_info'][i]['docId'])
-            termEntry['tfidf'][str(docNum)] = tf_idf
+            url = termEntry['doc_info'][i]['url']
+            termEntry['tfidf'][url] = tf_idf
             
         termEntry.save()
         

--- a/crawler/calculateTFIDF.py
+++ b/crawler/calculateTFIDF.py
@@ -23,9 +23,10 @@ def calculateTFIDF():
             if (tf != 0):
                 log_tf = math.log(tf, 2) + 1
             tf_idf = log_tf * idf
-            url = termEntry['doc_info'][i]['url']
-            termEntry['tfidf'][url] = tf_idf
-            
+            # url = termEntry['doc_info'][i]['url']
+            # termEntry['tfidf'][url] = tf_idf
+            termEntry['doc_info'][i]['tfidf']=tf_idf
+        
         termEntry.save()
         
     log("time", 'Execution finished in '+str(time.time()-startTime)+' seconds.')

--- a/crawler/calculateTFIDF.py
+++ b/crawler/calculateTFIDF.py
@@ -23,8 +23,6 @@ def calculateTFIDF():
             if (tf != 0):
                 log_tf = math.log(tf, 2) + 1
             tf_idf = log_tf * idf
-            # url = termEntry['doc_info'][i]['url']
-            # termEntry['tfidf'][url] = tf_idf
             termEntry['doc_info'][i]['tfidf']=tf_idf
         
         termEntry.save()

--- a/crawler/databaseBuilder.py
+++ b/crawler/databaseBuilder.py
@@ -105,9 +105,7 @@ class DatabaseBuilder:
           'termCount': 1,
           'pos':[termPos],
           'tfidf': 0
-        }],
-        tfidf={}
-        )
+        }])
         newTermEntry.save()
         DatabaseBuilder.termNum += 1
 

--- a/crawler/databaseBuilder.py
+++ b/crawler/databaseBuilder.py
@@ -12,7 +12,6 @@ import nltk
 nltk.download('stopwords', quiet=True)
 
 class DatabaseBuilder:
-  termNum=0
   connect(databaseName, host=databaseAddr, port=27017)
   stopwords = set(nltk.corpus.stopwords.words('english'))
   porterStemmer = nltk.stem.PorterStemmer()
@@ -99,7 +98,6 @@ class DatabaseBuilder:
 
       except DoesNotExist:
         newTermEntry = InvertedIndex(term=term,
-        termNum=DatabaseBuilder.termNum,
         doc_info=[{
           'url': url,
           'termCount': 1,
@@ -107,7 +105,6 @@ class DatabaseBuilder:
           'tfidf': 0
         }])
         newTermEntry.save()
-        DatabaseBuilder.termNum += 1
 
       if self.mode=='DEV' and termPos>=10:
         break

--- a/crawler/databaseBuilder.py
+++ b/crawler/databaseBuilder.py
@@ -122,7 +122,7 @@ class DatabaseBuilder:
     log('idf', 'Calculating IDF scores for all terms.')
     for termEntry in terms:
       docsContaining = float(len(termEntry.doc_info))
-      termEntry['idf'] = math.log(Crawler.objects.count / docsContaining, 2)
+      termEntry['idf'] = math.log(Crawler.objects.count() / docsContaining, 2)
       termEntry.save()
     log('time', 'IDF Execution finished in '+str(time.time() - startTime)+' seconds.')
   

--- a/crawler/databaseBuilder.py
+++ b/crawler/databaseBuilder.py
@@ -94,7 +94,7 @@ class DatabaseBuilder:
             break
 
         if not hasDoc:
-          termEntry.doc_info.append({'url':url, 'termCount': 1, 'pos':[termPos]})
+          termEntry.doc_info.append({'url':url, 'termCount': 1, 'pos':[termPos], 'tfidf':0})
         termEntry.save()
 
       except DoesNotExist:
@@ -103,7 +103,8 @@ class DatabaseBuilder:
         doc_info=[{
           'url': url,
           'termCount': 1,
-          'pos':[termPos]
+          'pos':[termPos],
+          'tfidf': 0
         }],
         tfidf={}
         )

--- a/crawler/mongoConfig.py
+++ b/crawler/mongoConfig.py
@@ -14,12 +14,8 @@ class Crawler(Document):
 
 class InvertedIndex(Document):
   term = StringField(required=True, primary_key=True)
-  #TODO we need to remove termNum once all other changes are made.
-  # termNum=IntField(required=True, min_value=0)
   doc_info = ListField(DictField(required=True), default=[])
   idf = FloatField(required=True, default=1)
-  #TODO we need to get rid of tfidf, check if it breaks later builds
-  tfidf = DictField(default={})
   created_at = DateTimeField(default=datetime.datetime.now())
   updated_at = DateTimeField(default=datetime.datetime.now())
 

--- a/crawler/mongoConfig.py
+++ b/crawler/mongoConfig.py
@@ -2,8 +2,7 @@ import datetime
 from mongoengine import *
 
 class Crawler(Document):
-  url = StringField(required=True)
-  _id = StringField(required=True, primary_key=True)
+  url = StringField(required=True, primary_key=True)
   title = StringField(required=True)
   description = StringField(required=True)
   body = StringField(required=True)

--- a/crawler/mongoConfig.py
+++ b/crawler/mongoConfig.py
@@ -14,7 +14,8 @@ class Crawler(Document):
 
 class InvertedIndex(Document):
   term = StringField(required=True, primary_key=True)
-  termNum=IntField(required=True, min_value=0)
+  #TODO we need to remove termNum once all other changes are made.
+  # termNum=IntField(required=True, min_value=0)
   doc_info = ListField(DictField(required=True), default=[])
   idf = FloatField(required=True, default=1)
   #TODO we need to get rid of tfidf, check if it breaks later builds

--- a/crawler/mongoConfig.py
+++ b/crawler/mongoConfig.py
@@ -17,6 +17,7 @@ class InvertedIndex(Document):
   termNum=IntField(required=True, min_value=0)
   doc_info = ListField(DictField(required=True), default=[])
   idf = FloatField(required=True, default=1)
+  #TODO we need to get rid of tfidf, check if it breaks later builds
   tfidf = DictField(default={})
   created_at = DateTimeField(default=datetime.datetime.now())
   updated_at = DateTimeField(default=datetime.datetime.now())
@@ -30,8 +31,8 @@ class User(Document):
   created_at = DateTimeField(default=datetime.datetime.now())
   updated_at = DateTimeField(default=datetime.datetime.now())
 
-# databaseName = 'ChefmateDB'
-databaseName = 'ChefmateDB_Alt'
+databaseName = 'ChefmateDB'
+# databaseName = 'ChefmateDB_Alt'
 
 # databaseAddr = '3.21.167.180'
 databaseAddr = '18.222.251.5'

--- a/ranker/cosineSimilarity.py
+++ b/ranker/cosineSimilarity.py
@@ -25,7 +25,7 @@ def cosineSimilarity(termWeights1, termWeights2):
 
   return top/bottom
 
-def calculateAllCosineSimilarity(terms, inMemoryTFIDF, crawlerReverseMap):
+def calculateAllCosineSimilarity(terms, inMemoryTFIDF, crawlerReverseMap, termReverseMap):
   startTime = time.time()
   connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
 
@@ -39,7 +39,7 @@ def calculateAllCosineSimilarity(terms, inMemoryTFIDF, crawlerReverseMap):
       for doc in docInfoList:
         docURLs.add(doc['url'])
 
-      termNum = int(termEntry['termNum'])
+      termNum = termReverseMap[term]
       queryTermWeights[termNum] += 1
     except DoesNotExist:
       log("query", 'Term not found - '+term)

--- a/ranker/loadInvertedIndexToMemory.py
+++ b/ranker/loadInvertedIndexToMemory.py
@@ -12,7 +12,7 @@ def loadInvertedIndexToMemory():
   log('info', 'Loading Inverted Index into main memory.')
   startTime=time.time()
 
-  invertedIndex = [(term['doc_info'], term['termNum']) for term in InvertedIndex.objects()]
+  invertedIndex = [(term['doc_info'], term['term']) for term in InvertedIndex.objects()]
   crawler = [document['url'] for document in Crawler.objects()]
   inMemoryTFIDF= np.zeros((InvertedIndex.objects.count(), Crawler.objects.count()))
 
@@ -20,10 +20,16 @@ def loadInvertedIndexToMemory():
   crawlerReverseMap = {}
   for i in range(0, len(crawler)):
     crawlerReverseMap[crawler[i]] = i
-  log('time', 'Finished building Crawler Reverse Map in ' + str(time.time()-crawlerMapTime) + ' seconds')
+  log('time', 'Finished building Crawler ReverseMap in ' + str(time.time()-crawlerMapTime) + ' seconds')
+
+  termMapTime = time.time()
+  termReverseMap = {}
+  for i in range(0, len(invertedIndex)):
+    termReverseMap[invertedIndex[i][1]]=i
+  log('time', 'Finished building Term ReverseMap in ' + str(time.time()-crawlerMapTime) + ' seconds')
 
   for termEntry in invertedIndex:
-    termNum = termEntry[1]
+    termNum = termReverseMap[termEntry[1]]
     for doc in termEntry[0]:
       url=doc['url']
       crawlerAxisPos = crawlerReverseMap[url]
@@ -33,4 +39,4 @@ def loadInvertedIndexToMemory():
         inMemoryTFIDF[termNum][crawlerAxisPos] = 0
 
   log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
-  return inMemoryTFIDF, crawlerReverseMap
+  return inMemoryTFIDF, crawlerReverseMap, termReverseMap

--- a/ranker/loadInvertedIndexToMemory.py
+++ b/ranker/loadInvertedIndexToMemory.py
@@ -1,0 +1,36 @@
+import sys
+import numpy as np
+import time
+sys.path.append('..')
+sys.path.append('../crawler')
+from mongoengine import *
+from mongoConfig import *
+from helpers import log
+
+
+def loadInvertedIndexToMemory():
+  log('info', 'Loading Inverted Index into main memory.')
+  startTime=time.time()
+
+  invertedIndex = [(term['doc_info'], term['termNum']) for term in InvertedIndex.objects()]
+  crawler = [document['url'] for document in Crawler.objects()]
+  inMemoryTFIDF= np.zeros((InvertedIndex.objects.count(), Crawler.objects.count()))
+
+  crawlerMapTime = time.time()
+  crawlerReverseMap = {}
+  for i in range(0, len(crawler)):
+    crawlerReverseMap[crawler[i]] = i
+  log('time', 'Finished building Crawler Reverse Map in ' + str(time.time()-crawlerMapTime) + ' seconds')
+
+  for termEntry in invertedIndex:
+    termNum = termEntry[1]
+    for doc in termEntry[0]:
+      url=doc['url']
+      crawlerAxisPos = crawlerReverseMap[url]
+      try:
+        inMemoryTFIDF[termNum][crawlerAxisPos] = doc['tfidf']
+      except:
+        inMemoryTFIDF[termNum][crawlerAxisPos] = 0
+
+  log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
+  return inMemoryTFIDF, crawlerReverseMap

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -12,13 +12,14 @@ from mongoengine import *
 from mongoConfig import *
 from cosineSimilarity import *
 import rankerDBConfig
+from loadInvertedIndexToMemory import loadInvertedIndexToMemory
 
 app = Flask(__name__)
 
 port = 8002
 connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
 
-inMemoryTFIDF = loadInvertedIndexToMemory()
+inMemoryTFIDF, crawlerReverseMap = loadInvertedIndexToMemory()
 
 @app.route('/', methods=["GET"])
 def index():
@@ -28,7 +29,7 @@ def index():
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   queryTerms = stemQuery(query)
-  sortedDocIds=calculateAllCosineSimilarity(queryTerms, inMemoryTFIDF)
+  sortedDocIds=calculateAllCosineSimilarity(queryTerms, inMemoryTFIDF, crawlerReverseMap)
   return helpers.sendPacket(1, 'Successfully retrieved query', {'sortedDocIds':sortedDocIds})
 
 @app.route('/fetchDocuments', methods=['POST'])

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -40,8 +40,7 @@ def fetchDocuments():
   documents=[]
   for url in docUrls:
     documents.append(Crawler.objects.get(url=url).to_json())
-  # for docId in docIds:
-    # documents.append(Crawler.objects.get(_id=str(docId)).to_json())
+
   log('ranker', 'Finished fetching documents in '+str(time.time() - startTime) + ' seconds')
   return helpers.sendPacket(1, 'Successfully retrieved documents', {'documents':documents})
 

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -19,7 +19,7 @@ app = Flask(__name__)
 port = 8002
 connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
 
-inMemoryTFIDF, crawlerReverseMap = loadInvertedIndexToMemory()
+inMemoryTFIDF, crawlerReverseMap, termReverseMap = loadInvertedIndexToMemory()
 
 @app.route('/', methods=["GET"])
 def index():
@@ -29,7 +29,7 @@ def index():
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   queryTerms = stemQuery(query)
-  sortedDocUrls=calculateAllCosineSimilarity(queryTerms, inMemoryTFIDF, crawlerReverseMap)
+  sortedDocUrls=calculateAllCosineSimilarity(queryTerms, inMemoryTFIDF, crawlerReverseMap, termReverseMap)
   return helpers.sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls})
 
 @app.route('/fetchDocuments', methods=['POST'])

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -29,17 +29,19 @@ def index():
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   queryTerms = stemQuery(query)
-  sortedDocIds=calculateAllCosineSimilarity(queryTerms, inMemoryTFIDF, crawlerReverseMap)
-  return helpers.sendPacket(1, 'Successfully retrieved query', {'sortedDocIds':sortedDocIds})
+  sortedDocUrls=calculateAllCosineSimilarity(queryTerms, inMemoryTFIDF, crawlerReverseMap)
+  return helpers.sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls})
 
 @app.route('/fetchDocuments', methods=['POST'])
 def fetchDocuments():
   startTime = time.time()
-  docIds = request.json['docIds']
+  docUrls = request.json['docUrls']
   log('ranker', 'Fetching documents')
   documents=[]
-  for docId in docIds:
-    documents.append(Crawler.objects.get(_id=str(docId)).to_json())
+  for url in docUrls:
+    documents.append(Crawler.objects.get(url=url).to_json())
+  # for docId in docIds:
+    # documents.append(Crawler.objects.get(_id=str(docId)).to_json())
   log('ranker', 'Finished fetching documents in '+str(time.time() - startTime) + ' seconds')
   return helpers.sendPacket(1, 'Successfully retrieved documents', {'documents':documents})
 

--- a/ranker/rankerDBConfig.py
+++ b/ranker/rankerDBConfig.py
@@ -1,5 +1,5 @@
-databaseName = 'ChefmateDB'
-# databaseName = 'ChefmateDB_Alt'
+# databaseName = 'ChefmateDB'
+databaseName = 'ChefmateDB_Alt'
 
 # databaseAddr = '3.21.167.180'
 databaseAddr = '18.222.251.5'

--- a/ranker/rankerDBConfig.py
+++ b/ranker/rankerDBConfig.py
@@ -1,5 +1,5 @@
-databaseName = 'ChefmateDB'
-# databaseName = 'ChefmateDB_Alt'
+# databaseName = 'ChefmateDB'
+databaseName = 'ChefmateDB_Alt'
 
-databaseAddr = '3.21.167.180'
-# databaseAddr = '18.222.251.5'
+# databaseAddr = '3.21.167.180'
+databaseAddr = '18.222.251.5'

--- a/ranker/rankerDBConfig.py
+++ b/ranker/rankerDBConfig.py
@@ -1,5 +1,5 @@
-# databaseName = 'ChefmateDB'
-databaseName = 'ChefmateDB_Alt'
+databaseName = 'ChefmateDB'
+# databaseName = 'ChefmateDB_Alt'
 
 # databaseAddr = '3.21.167.180'
 databaseAddr = '18.222.251.5'


### PR DESCRIPTION
**Updates**
1. Switch Crawler object primary key to be URL and make all necessary dependency changes
2. Update Cosine Similarity to no longer depend on Crawler object num
3. Remove manually assigned docId from DatabaseBuilder. This should really help us with recovering from crashes.
4. Remove manually assigned termNum and instead switch to a in-memory map

**Testing Plan**
If anyone else sees this, I am waiting for crawler to finish running on a larger dataset to see if this new fix still works before I merge it.

Run ranker, see that everything still works on the client.