### PR TITLE
Removed www. from start of sites, and removed > from end of old modify

### DIFF
--- a/client/frontend/src/SearchResult/SingleResult.js
+++ b/client/frontend/src/SearchResult/SingleResult.js
@@ -48,8 +48,12 @@ export default function SingleResult(props: Props) {
   function changeUrl() {
     var output = '';
     let i = props.url.substr(0, 8) == 'https://' ? 8 : 0;
-    for (i; i < props.url.length; i++)
-      props.url[i] == '/' ? (output += '>') : (output += props.url[i]);
+    if (props.url.substr(i, 4) === 'www.') i += 4;
+    for (i; i < props.url.length; i++) {
+      if (props.url[i] == '/') {
+        if (i !== props.url.length - 1) output += ' > ';
+      } else output += props.url[i];
+    }
     return output;
   }
 


### PR DESCRIPTION
**Updates**
1. Remove www. from start of sites that have it
2. Remove > if / occurs at last character

**Testing Plan**
Look at all urls, see that its still readable