### PR TITLE
Crawl the Site using XML Sitemap

### DIFF
--- a/crawler/buildIndex.py
+++ b/crawler/buildIndex.py
@@ -47,21 +47,15 @@ def buildIndex(iterations, reset=True, resetFiles=True, passwordLock=True, dev=F
   for domain in domains:
     domainStartTime = time.time()
 
-    if options['crawl']:
-      crawler = Crawler(domain['name'], domain['root'])
-      crawler.runSpider(iterations)
+    options['crawl'] and Crawler(domain['name'], domain['root']).runSpider(iterations)
 
     inlinkGraphFile = 'domains/'+domain['name']+'/'+domain['name']+'_inlinks.json'
     outlinkGraphFile = 'domains/'+domain['name']+'/'+domain['name']+'_outlinks.json'
     options['pageRank'] and calculatePageRank(domain['name'], inlinkGraphFile, outlinkGraphFile, 3)
 
-    if options['parse']:
-      dataParser = DataParser(domain['name'])
-      dataParser.runParser()
+    options['parse'] and DataParser(domain['name']).runParser()
 
-    if options['database']:
-      databaseBuilder = DatabaseBuilder(domain['name'], mode='DEV' if dev else 'PROD')
-      databaseBuilder.build()
+    options['database'] and DatabaseBuilder(domain['name'], mode='DEV' if dev else 'PROD').build()
 
     log("time", domain['name']+" finished running in "+str(time.time()-domainStartTime)+" seconds.")
   

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -46,11 +46,10 @@ class Crawler:
     xmlQueue = set()
     xmlQueue.add(self.sitemapURL)
     htmlQueue = set()
-    log('sitemap', 'Crawling XML Sitemap for '+self.domainName)
+    log('sitemap', 'Crawling XML Sitemap for '+self.siteName)
 
     while(len(xmlQueue) != 0):
       nextParse = requests.get(xmlQueue.pop(), headers=headers)
-      xmlCrawled.add(nextParse)
       newXMLLinks = self.findNewLinksXML(nextParse)
       for link in newXMLLinks:
         if link[-4:]=='.xml':
@@ -61,7 +60,7 @@ class Crawler:
 
     FileIO.deleteFileContents(self.queueFile)
     FileIO.setToFile(htmlQueue, self.queueFile)
-    log('time', 'Finished crawling XML sitemap for '+self.domainName+' in '+str(time.time() - startTime)+' seconds')
+    log('time', 'Finished crawling XML sitemap for '+self.siteName+' in '+str(time.time() - startTime)+' seconds')
 
   def findNewLinks(self, parseLink):
     try:
@@ -102,13 +101,9 @@ class Crawler:
 
       if href[0] == '/':
         output.add(self.baseURL + href)
-        # self.outlinkGraph.addLink(parseLink, self.baseURL + href)
-        # self.inlinkGraph.addLink(self.baseURL + href, parseLink)
 
       elif href[:len(self.baseURL)] == self.baseURL:
         output.add(href)
-        # self.outlinkGraph.addLink(parseLink, href)
-        # self.inlinkGraph.addLink(href, parseLink)
 
     return output
 
@@ -186,11 +181,9 @@ class Crawler:
 
 
 if __name__ == "__main__":
-  crawler = Crawler('simpleRecipes', 'https://www.simplyrecipes.com/')
-  crawler.runSitemapCrawler()
+  # crawler = Crawler('simpleRecipes', 'https://www.simplyrecipes.com/')
   # crawler = Crawler('simpleRecipes', 'https://www.epicurious.com/')
-  # crawler.runSitemapCrawler()
-  # crawler = Crawler('simpleRecipes', 'https://www.tasty.co/')
-  # crawler.runSitemapCrawler()
+  crawler = Crawler('simpleRecipes', 'https://www.tasty.co/')
+  crawler.runSitemapCrawler()
   # crawler.runSpider(3)
   

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -25,6 +25,18 @@ class Crawler:
     self.inlinkGraph = Graph()
     self.inlinkGraphFile = 'domains/' + siteName + '/' + siteName + '_inlinks.json'
     self.outlinkGraphFile = 'domains/' + siteName + '/' + siteName + '_outlinks.json'
+  
+  def findXMLSitemap(self):
+    headers = {'User-Agent':"Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36"}
+    robots = requests.get(self.baseURL+'robots.txt', headers=headers)
+    soup = BeautifulSoup(robots.content, 'lxml')
+    rawText = soup.find_all('p')[0].text
+    siteMapLink = ''
+    for line in rawText.split('\n'):
+      if line[:len("Sitemap:")] == "Sitemap:" and line[-4:]=='.xml':
+        siteMapLink=line.split(' ')[1]
+        break
+    print(siteMapLink)
 
   def findNewLinks(self, parseLink):
     try:
@@ -45,7 +57,8 @@ class Crawler:
       log('error', 'Request exception')
       return set()
 
-    page = requests.get(parseLink)
+    headers = {'User-Agent':"Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36"}
+    page = requests.get(parseLink, headers=headers)
     contentType = 'content-type' if 'content-type' in head.headers else 'Content-type'
     if head.headers[contentType] == 'text/xml':
       return self.findNewLinksXML(parseLink, page)
@@ -152,8 +165,12 @@ class Crawler:
 
 if __name__ == "__main__":
   crawler = Crawler('simpleRecipes', 'https://www.simplyrecipes.com/')
+  crawler.findXMLSitemap()
+
+  crawler = Crawler('simpleRecipes', 'https://www.epicurious.com/')
+  crawler.findXMLSitemap()
+
+  crawler = Crawler('simpleRecipes', 'https://www.tasty.co/')
+  crawler.findXMLSitemap()
   # crawler.runSpider(3)
-  print(crawler.findNewLinks('https://www.simplyrecipes.com/recipes/cowboy_beans/%5d'))
-  # print(crawler.findNewLinks('https://www.simplyrecipes.com/recipes/type/grill/low_carb/'))
-  # print(crawler.findNewLinks('https://www.simplyrecipes.com/'))
   

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -82,7 +82,7 @@ class Crawler:
   def findNewLinks(self, parseLink):
     try:
       head=requests.head(parseLink)
-      if ('content-type' not in head.headers and 'Content-type' not in head.headers) or ("text/html" not in head.headers['content-type'] and "text/xml" not in head.headers['Content-type']):
+      if ('content-type' not in head.headers and 'Content-type' not in head.headers) or ("text/html" not in head.headers['content-type'] and "text/html" not in head.headers['Content-type']):
         log("error", 'Invalid page type')
         return set()
     except requests.exceptions.HTTPError as errh:
@@ -100,10 +100,7 @@ class Crawler:
 
     headers = {'User-Agent':"Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36"}
     page = requests.get(parseLink, headers=headers)
-    contentType = 'content-type' if 'content-type' in head.headers else 'Content-type'
-    if head.headers[contentType] == 'text/xml':
-      return self.findNewLinksXML(parseLink, page)
-
+    
     return self.findNewLinksHTML(parseLink, page)
 
   def findNewLinksHTML(self, parseLink, page):

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -96,8 +96,8 @@ class Crawler:
       href = link.text
       if href is None or len(href) == 0:
         continue
-      # if href[:len(self.baseURL)] == self.baseURL:
-      output.add(href)
+      if href[:len(self.baseURL)] == self.baseURL or href[:len(self.baseURL)-4] == self.baseURL.replace('www.','',1):
+        output.add(href)
 
     return output
 

--- a/crawler/crawler.py
+++ b/crawler/crawler.py
@@ -15,7 +15,6 @@ class Crawler:
     self.siteName = siteName
     self.baseURL = baseURL
     self.domainName = Crawler.getDomainName(baseURL)
-    ##TODO Will need to move this down below
     FileIO.createSiteFileSetup(self.siteName, self.baseURL)
     self.queueFile = 'domains/' + siteName + '/' + siteName + '_queue.txt'
     self.crawledFile = 'domains/' + siteName + '/' + siteName + '_crawled.txt'
@@ -52,7 +51,7 @@ class Crawler:
       nextParse = requests.get(xmlQueue.pop(), headers=headers)
       newXMLLinks = self.findNewLinksXML(nextParse)
       for link in newXMLLinks:
-        if link[-4:]=='.xml':
+        if '.xml' in link:
           if 'archive' not in link:
             xmlQueue.add(link)
         else:
@@ -95,15 +94,10 @@ class Crawler:
 
     for link in soup.find_all('loc'):
       href = link.text
-
       if href is None or len(href) == 0:
         continue
-
-      if href[0] == '/':
-        output.add(self.baseURL + href)
-
-      elif href[:len(self.baseURL)] == self.baseURL:
-        output.add(href)
+      # if href[:len(self.baseURL)] == self.baseURL:
+      output.add(href)
 
     return output
 

--- a/crawler/dataParser.py
+++ b/crawler/dataParser.py
@@ -1,6 +1,5 @@
 from fileIO import FileIO
 import json
-# import uuid
 import os
 import sys
 sys.path.append('..')
@@ -9,7 +8,6 @@ log = helpers.log
 from extractData import extractData
 
 class DataParser:
-  docId=0
   def __init__(self, siteName):
     self.siteName = siteName
     self.crawledFile = 'domains/' + siteName + '/' + siteName + '_crawled.txt'
@@ -29,12 +27,10 @@ class DataParser:
       if link not in data:
         obj = extractData(link)
         data[link] = {
-            'docId': DataParser.docId,
             'title': obj['title'],
             'body': obj['body'],
             'description': obj['description']
         }
-        DataParser.docId+=1
     FileIO.deleteFileContents(self.indexFile)
     FileIO.writeJsonFile(data, self.indexFile)
 

--- a/crawler/databaseBuilder.py
+++ b/crawler/databaseBuilder.py
@@ -8,8 +8,18 @@ from mongoConfig import *
 import math
 import time
 
+import ssl
 import nltk
+
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    pass
+else:
+    ssl._create_default_https_context = _create_unverified_https_context
+
 nltk.download('stopwords', quiet=True)
+nltk.download('punkt', quiet=True)
 
 class DatabaseBuilder:
   connect(databaseName, host=databaseAddr, port=27017)

--- a/crawler/extractData.py
+++ b/crawler/extractData.py
@@ -12,7 +12,9 @@ def extractData(baseURL):
   log('parse', baseURL)
   startTime = time.time()
 
-  page = requests.get(baseURL).content
+  headers = {'User-Agent':"Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36"}
+
+  page = requests.get(baseURL, headers=headers).content
   soup = BeautifulSoup(page, "lxml")
   title = soup.title.string if soup.title!=None else baseURL
 

--- a/crawler/extractData.py
+++ b/crawler/extractData.py
@@ -7,7 +7,6 @@ import sys
 sys.path.append('..')
 from helpers import log
 
-#TODO need to do something else if XML
 def extractData(baseURL):
   log('parse', baseURL)
   startTime = time.time()
@@ -29,4 +28,5 @@ def extractData(baseURL):
   return output
         
 if __name__ == "__main__":
-    extractData("https://www.simplyrecipes.com/recipes/cuisine/indian/")
+    data = extractData("https://www.epicurious.com/type/salad")
+    print(data['description'])

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -16,6 +16,10 @@ from stemQuery import stemQuery
 import rankerDBConfig
 from loadInvertedIndexToMemory import loadInvertedIndexToMemory
 
+import nltk
+nltk.download('stopwords', quiet=True)
+nltk.download('punkt', quiet=True)
+
 app = Flask(__name__)
 
 port = 8002 if app.config['ENV']=='development' else 80

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -16,7 +16,16 @@ from stemQuery import stemQuery
 import rankerDBConfig
 from loadInvertedIndexToMemory import loadInvertedIndexToMemory
 
+import ssl
 import nltk
+
+try:
+    _create_unverified_https_context = ssl._create_unverified_context
+except AttributeError:
+    pass
+else:
+    ssl._create_default_https_context = _create_unverified_https_context
+
 nltk.download('stopwords', quiet=True)
 nltk.download('punkt', quiet=True)
 


### PR DESCRIPTION
**Updates**
1. Uses XML sitemap to compile full list of siteURLs. We probably won't do this because we don't have the resources. It would require a fuckton of memory. Good to have it done though. Additionally, we will still need to run the ol default crawler because we can't calculate pageRank Otherwise. Maybe sometime in the future if we create a continuous crawler that nonstop runs in the background, we can do this.

2. Adds nltk.download('punkt') to ranker
3. Creates SSL avoidance plan to get rid of annoying nltk download error messages.

**Testing Plan**
Run crawler, and whole project to see that everything is still fine.
