### PR TITLE
Update ranker to avoid InMemoryTFIDF

### DIFF
--- a/client/mongoConfig.js
+++ b/client/mongoConfig.js
@@ -1,8 +1,8 @@
 const mongoose = require("mongoose");
 const log = require('./logger');
 
-// const databaseAddr = '18.222.251.5';
-const databaseAddr = '3.21.167.180';
+const databaseAddr = '18.222.251.5';
+// const databaseAddr = '3.21.167.180';
 
 const databaseName = 'ChefmateDB'
 // const databaseName = 'ChefmateDB_Alt'

--- a/client/mongoConfig.js
+++ b/client/mongoConfig.js
@@ -1,8 +1,8 @@
 const mongoose = require("mongoose");
 const log = require('./logger');
 
-const databaseAddr = '18.222.251.5';
-// const databaseAddr = '3.21.167.180';
+// const databaseAddr = '18.222.251.5';
+const databaseAddr = '3.21.167.180';
 
 const databaseName = 'ChefmateDB'
 // const databaseName = 'ChefmateDB_Alt'

--- a/client/mongoConfig.js
+++ b/client/mongoConfig.js
@@ -30,7 +30,12 @@ const CrawlerSchema = new mongoose.Schema(
       required: [true, "Authority is required"],
       default: 1
     },
-    pageRank: { type: Number, required: [true, "PageRank is required"], default: 1 }
+    pageRank: { type: Number, required: [true, "PageRank is required"], default: 1 },
+    tfidf: {
+      type: {}, 
+      required: [true, 'Initial TFIDF is required. Default is {}'], 
+      default: {}
+    }
   },
   { timestamps: true }
 );

--- a/client/routes/search.js
+++ b/client/routes/search.js
@@ -7,7 +7,7 @@ const { User, Query } = require('../mongoConfig');
 module.exports = (app) => {
   app.get('/search/:query', async (request, response) => {
     const query = request.params['query'];
-    log('query', `Received query from client: ${query}`);
+    log('query', `Received query from client: ${query}. Sending data to ranker`);
     const data = await makeRequest('ranker', `query/${query}`);
 
     Query.findById(query, (err, oldQueryObj) => {
@@ -25,7 +25,7 @@ module.exports = (app) => {
       }
     });
 
-    log('ranker', data.message);
+    log('Fetch', `Received response from Ranker: ${data.message}`);
     return response.json(
       sendPacket(
         data.success,
@@ -37,7 +37,7 @@ module.exports = (app) => {
 
   app.post('/fetchDocuments', async (req, res) => {
     const startTime = Date.now();
-    log('fetch', 'Fetching documents from ranker');
+    log('fetch', 'Fetching documents from ranker using sorted list of document urls');
 
     const docUrls = req.body['docUrls'].slice(0, 60);
     const data = await makeRequest('ranker', 'fetchDocuments', 'POST', {

--- a/crawler/calculateTFIDF.py
+++ b/crawler/calculateTFIDF.py
@@ -22,10 +22,10 @@ def calculateTFIDF():
                 log_tf = math.log(tf, 2) + 1
             tf_idf = log_tf * idf
 
-            url = docInfoList[docKey]['url']
+            url = termEntry['doc_info'][docKey]['url']
             if url[0:8] == 'https://':
                 document = Crawler.objects.get(url=url)
-                if tfidf not in document:
+                if 'tfidf' not in document:
                     document['tfidf'] = {}
                 document['tfidf'][term] = tf_idf
                 document.save()

--- a/crawler/calculateTFIDF.py
+++ b/crawler/calculateTFIDF.py
@@ -21,7 +21,7 @@ def calculateTFIDF():
             if (tf != 0):
                 log_tf = math.log(tf, 2) + 1
             tf_idf = log_tf * idf
-            # termEntry['doc_info'][docKey]['tfidf']=tf_idf
+
             url = docInfoList[docKey]['url']
             if url[0:8] == 'https://':
                 document = Crawler.objects.get(url=url)
@@ -29,9 +29,7 @@ def calculateTFIDF():
                     document['tfidf'] = {}
                 document['tfidf'][term] = tf_idf
                 document.save()
-        
-        # termEntry.save()
-        
+                
     log("time", 'Execution finished in '+str(time.time()-startTime)+' seconds.')
 
 if __name__ == "__main__":

--- a/crawler/calculateTFIDF.py
+++ b/crawler/calculateTFIDF.py
@@ -14,7 +14,6 @@ def calculateTFIDF():
     for termEntry in terms: 
         term = termEntry['term']
         idf = termEntry['idf']
-        # log("tfidf", 'Calculating '+term)
 
         for docKey in termEntry["doc_info"]:
             tf = termEntry['doc_info'][docKey]['termCount']
@@ -22,9 +21,16 @@ def calculateTFIDF():
             if (tf != 0):
                 log_tf = math.log(tf, 2) + 1
             tf_idf = log_tf * idf
-            termEntry['doc_info'][docKey]['tfidf']=tf_idf
+            # termEntry['doc_info'][docKey]['tfidf']=tf_idf
+            url = docInfoList[docKey]['url']
+            if url[0:8] == 'https://':
+                document = Crawler.objects.get(url=url)
+                if tfidf not in document:
+                    document['tfidf'] = {}
+                document['tfidf'][term] = tf_idf
+                document.save()
         
-        termEntry.save()
+        # termEntry.save()
         
     log("time", 'Execution finished in '+str(time.time()-startTime)+' seconds.')
 

--- a/crawler/databaseBuilder.py
+++ b/crawler/databaseBuilder.py
@@ -109,7 +109,6 @@ class DatabaseBuilder:
           'url': url,
           'termCount': 1,
           'pos':[termPos],
-          'tfidf': 0
         }})
         newTermEntry.save()
 

--- a/crawler/databaseBuilder.py
+++ b/crawler/databaseBuilder.py
@@ -75,7 +75,7 @@ class DatabaseBuilder:
   
   def addDocumentToCollection(self, url, title, body, description, pageRank):
     log("crawler", "Adding "+url+" to collection.")
-    crawlerDoc = Crawler(url=url, title=title, body=body, description=description, pageRank=pageRank, tfidf={})
+    crawlerDoc = Crawler(url=url, title=title, body=body, description=description, pageRank=pageRank, tfidf={'Ashwin': 0})
     crawlerDoc.save()
     
   def buildInvertedIndex(self, body, url):

--- a/crawler/databaseBuilder.py
+++ b/crawler/databaseBuilder.py
@@ -75,7 +75,7 @@ class DatabaseBuilder:
   
   def addDocumentToCollection(self, url, title, body, description, pageRank):
     log("crawler", "Adding "+url+" to collection.")
-    crawlerDoc = Crawler(url=url, title=title, body=body, description=description, pageRank=pageRank)
+    crawlerDoc = Crawler(url=url, title=title, body=body, description=description, pageRank=pageRank, tfidf={})
     crawlerDoc.save()
     
   def buildInvertedIndex(self, body, url):

--- a/crawler/mongoConfig.py
+++ b/crawler/mongoConfig.py
@@ -11,6 +11,7 @@ class Crawler(Document):
   pageRank = FloatField(required=True, default=1.0)
   created_at = DateTimeField(default=datetime.datetime.now())
   updated_at = DateTimeField(default=datetime.datetime.now())
+  tfidf = DictField(required=True, default={})
 
 class InvertedIndex(Document):
   term = StringField(required=True, primary_key=True)

--- a/ranker/loadInvertedIndexToMemory.py
+++ b/ranker/loadInvertedIndexToMemory.py
@@ -14,35 +14,9 @@ def loadInvertedIndexToMemory():
 
   invertedIndex = [(term['doc_info'], term['term']) for term in InvertedIndex.objects()]
   
-  # documents = []
-  # pageRanks = []
-  # authority = []
-  # for document in Crawler.objects():
-  #   documents.append(document['url'])
-  #   pageRanks.append(document['pageRank'])
-  #   authority.append(document['authority'])
-
-  # inMemoryTFIDF= np.zeros((InvertedIndex.objects.count(), Crawler.objects.count()))
-
-  # crawlerReverseMap = {}
-  # for i in range(0, len(documents)):
-  #   crawlerReverseMap[documents[i]] = i
-
   termReverseMap = {}
   for i in range(0, len(invertedIndex)):
     termReverseMap[invertedIndex[i][1]] = i
 
-  # for termEntry in invertedIndex:
-  #   termNum = termReverseMap[termEntry[1]]
-  #   for docKey in termEntry[0]:
-  #     doc = termEntry[0][docKey]
-  #     url=doc['url']
-  #     crawlerAxisPos = crawlerReverseMap[url]
-  #     try:
-  #       inMemoryTFIDF[termNum][crawlerAxisPos] = doc['tfidf']
-  #     except:
-  #       inMemoryTFIDF[termNum][crawlerAxisPos] = 0
-
   log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
-  # return inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority
   return termReverseMap

--- a/ranker/loadInvertedIndexToMemory.py
+++ b/ranker/loadInvertedIndexToMemory.py
@@ -14,34 +14,35 @@ def loadInvertedIndexToMemory():
 
   invertedIndex = [(term['doc_info'], term['term']) for term in InvertedIndex.objects()]
   
-  documents = []
-  pageRanks = []
-  authority = []
-  for document in Crawler.objects():
-    documents.append(document['url'])
-    pageRanks.append(document['pageRank'])
-    authority.append(document['authority'])
+  # documents = []
+  # pageRanks = []
+  # authority = []
+  # for document in Crawler.objects():
+  #   documents.append(document['url'])
+  #   pageRanks.append(document['pageRank'])
+  #   authority.append(document['authority'])
 
-  inMemoryTFIDF= np.zeros((InvertedIndex.objects.count(), Crawler.objects.count()))
+  # inMemoryTFIDF= np.zeros((InvertedIndex.objects.count(), Crawler.objects.count()))
 
-  crawlerReverseMap = {}
-  for i in range(0, len(documents)):
-    crawlerReverseMap[documents[i]] = i
+  # crawlerReverseMap = {}
+  # for i in range(0, len(documents)):
+  #   crawlerReverseMap[documents[i]] = i
 
   termReverseMap = {}
   for i in range(0, len(invertedIndex)):
     termReverseMap[invertedIndex[i][1]] = i
 
-  for termEntry in invertedIndex:
-    termNum = termReverseMap[termEntry[1]]
-    for docKey in termEntry[0]:
-      doc = termEntry[0][docKey]
-      url=doc['url']
-      crawlerAxisPos = crawlerReverseMap[url]
-      try:
-        inMemoryTFIDF[termNum][crawlerAxisPos] = doc['tfidf']
-      except:
-        inMemoryTFIDF[termNum][crawlerAxisPos] = 0
+  # for termEntry in invertedIndex:
+  #   termNum = termReverseMap[termEntry[1]]
+  #   for docKey in termEntry[0]:
+  #     doc = termEntry[0][docKey]
+  #     url=doc['url']
+  #     crawlerAxisPos = crawlerReverseMap[url]
+  #     try:
+  #       inMemoryTFIDF[termNum][crawlerAxisPos] = doc['tfidf']
+  #     except:
+  #       inMemoryTFIDF[termNum][crawlerAxisPos] = 0
 
   log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
-  return inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority
+  # return inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority
+  return termReverseMap

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -7,7 +7,6 @@ import numpy as np
 import time
 from cosineSimilarity import cosineSimilarity
 
-# def rank(terms, inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority):
 def rank(terms, termReverseMap):
   startTime = time.time()
 

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -10,6 +10,7 @@ from cosineSimilarity import cosineSimilarity
 def rank(terms, termReverseMap):
   startTime = time.time()
 
+  log("Ranking", 'Calculating rankings for query')
   docURLs = set()
   queryTermWeights = np.zeros(len(termReverseMap))
   queryStr=''

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -42,7 +42,11 @@ def rank(terms, termReverseMap):
       termNum = termReverseMap.get(term)
       if(termNum == None):
         continue
-      docWeights[termNum] += 1
+      if 'tfidf' not in document or term not in document['tfidf']:
+        docWeights[termNum] += 1
+      else:
+        tfidf = document['tfidf'][term]
+        docWeights[termNum] += tfidf
 
     rankVal = (cosineSimilarity(queryTermWeights, docWeights) * 0.85) + (document['pageRank'] * 0.08) + (document['authority'] * 0.07)
 

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -20,7 +20,9 @@ def rank(terms, termReverseMap):
 
       docInfoList=termEntry['doc_info']
       for docKey in docInfoList:
-        docURLs.add(docInfoList[docKey]['url'])
+        url = docInfoList[docKey]['url']
+        if url[0:8] == 'https://':
+          docURLs.add(url)
 
       termNum = termReverseMap[term]
       queryTermWeights[termNum] += 1
@@ -32,6 +34,9 @@ def rank(terms, termReverseMap):
 
   for url in docURLs:
     document = Crawler.objects.get(url=url)
+    if 'Page not found' in document['title']:
+      continue
+
     docWeights = np.zeros(len(termReverseMap))
     for term in document['body']:
       termNum = termReverseMap.get(term)

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -38,12 +38,12 @@ def rank(terms, termReverseMap):
       continue
 
     docWeights = np.zeros(len(termReverseMap))
-    for term in document['body']:
+    for term in document['body'].lower().split():
       termNum = termReverseMap.get(term)
       if(termNum == None):
         continue
       if 'tfidf' not in document or term not in document['tfidf']:
-        docWeights[termNum] += 1
+        docWeights[termNum] += 0.01
       else:
         tfidf = document['tfidf'][term]
         docWeights[termNum] += tfidf

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -45,7 +45,7 @@ def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   queryTerms = stemQuery(query)
   sortedDocUrls = rank(queryTerms, termReverseMap)
-  return sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls})
+  return sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls[0:200]})
 
 @app.route('/fetchDocuments', methods=['POST'])
 def fetchDocuments():

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -34,7 +34,6 @@ app = Flask(__name__)
 port = 80 if app.config['ENV']=='production' else 8002
 connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
 
-# inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority = loadInvertedIndexToMemory()
 termReverseMap = loadInvertedIndexToMemory()
 
 @app.route('/', methods=["GET"])
@@ -45,7 +44,6 @@ def index():
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   queryTerms = stemQuery(query)
-  # sortedDocUrls=rank(queryTerms, inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority)
   sortedDocUrls = rank(queryTerms, termReverseMap)
   return sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls})
 

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -34,7 +34,8 @@ app = Flask(__name__)
 port = 80 if app.config['ENV']=='production' else 8002
 connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
 
-inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority = loadInvertedIndexToMemory()
+# inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority = loadInvertedIndexToMemory()
+termReverseMap = loadInvertedIndexToMemory()
 
 @app.route('/', methods=["GET"])
 def index():
@@ -44,7 +45,8 @@ def index():
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   queryTerms = stemQuery(query)
-  sortedDocUrls=rank(queryTerms, inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority)
+  # sortedDocUrls=rank(queryTerms, inMemoryTFIDF, crawlerReverseMap, termReverseMap, pageRanks, authority)
+  sortedDocUrls = rank(queryTerms, termReverseMap)
   return sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls})
 
 @app.route('/fetchDocuments', methods=['POST'])

--- a/ranker/rankerDBConfig.py
+++ b/ranker/rankerDBConfig.py
@@ -1,5 +1,5 @@
 databaseName = 'ChefmateDB'
 # databaseName = 'ChefmateDB_Alt'
 
-# databaseAddr = '3.21.167.180'
-databaseAddr = '18.222.251.5'
+databaseAddr = '3.21.167.180'
+# databaseAddr = '18.222.251.5'

--- a/ranker/rankerDBConfig.py
+++ b/ranker/rankerDBConfig.py
@@ -1,5 +1,5 @@
 databaseName = 'ChefmateDB'
 # databaseName = 'ChefmateDB_Alt'
 
-databaseAddr = '3.21.167.180'
-# databaseAddr = '18.222.251.5'
+# databaseAddr = '3.21.167.180'
+databaseAddr = '18.222.251.5'


### PR DESCRIPTION
**Updates**
1. Removes in memoryTFIDF so that we can do more with less memory. This will significantly impact the speed of our search results

NOTE: Before I merge, I'm going to add an option so that we can still use the old way by using a randomly selected subset of our corpus

**Testing Plan**
Make some searches and see that results are still popping up, ranked well.
