### PR TITLE
Implement Pseudo-Relevance Feedback

### DIFF
--- a/crawler/calculateTFIDF.py
+++ b/crawler/calculateTFIDF.py
@@ -37,9 +37,9 @@ def tfidfWorker():
           except DoesNotExist:
             continue
           if 'tfidf' not in document:
-            document['tfidf'] = {}
-            document['tfidf'][term] = tf_idf
-            document.save()
+            document['tfidf'] = {'Ashwin': 0}
+          document['tfidf'][term.replace('.', ',')] = tf_idf
+          document.save()
 
     log('time', 'Finished calculating tfidf for letter ' + currentLetter.upper() + ' in ' + str(time.time() - startTime) + ' seconds')
 

--- a/crawler/calculateTFIDF.py
+++ b/crawler/calculateTFIDF.py
@@ -37,7 +37,7 @@ def tfidfWorker():
           except DoesNotExist:
             continue
           if 'tfidf' not in document:
-            document['tfidf'] = {'Ashwin': 0}
+            document['tfidf'] = {}
           document['tfidf'][term.replace('.', ',')] = tf_idf
           document.save()
 

--- a/ranker/cosineSimilarity.py
+++ b/ranker/cosineSimilarity.py
@@ -16,4 +16,6 @@ def cosineSimilarity(termWeights1, termWeights2):
   magnitude2 = np.dot(termWeights2, termWeights2.T)
   bottom = sqrt(magnitude1*magnitude2)
 
+  if(bottom == 0):
+    return 0
   return top/bottom

--- a/ranker/fetchDocuments.py
+++ b/ranker/fetchDocuments.py
@@ -9,17 +9,17 @@ from helpers import log
 
 from nltk.stem import PorterStemmer 
 
-def fetchDocuments(stemmedQueryTerms, invertedIndex):
+def fetchDocuments(stemmedQueryTerms, invertedIndex, queryExpansion=False):
   expandedList = []
   for term in stemmedQueryTerms:
     expandedList.append(term)
 
-  for queryTerm in stemmedQueryTerms:
-     expandedList += [term for chiSquare, term in queryExpansion(queryTerm, invertedIndex)]
+  if queryExpansion:
+    for queryTerm in stemmedQueryTerms:
+      expandedList += [term for chiSquare, term in queryExpansion(queryTerm, invertedIndex)]
   
   termDBObjects = []
   for term in expandedList:
-    #InvertedIndex already being passed in. Use the one being passed in to fetch term
     try:
       termEntry = InvertedIndex.objects.get(term=term)
       termDBObjects.append(termEntry)

--- a/ranker/fetchDocuments.py
+++ b/ranker/fetchDocuments.py
@@ -1,4 +1,4 @@
-from queryExpansion import queryExpansion
+from queryExpansion import performQueryExpansion
 from mongoConfig import *
 import sys
 sys.path.append('..')
@@ -16,7 +16,7 @@ def fetchDocuments(stemmedQueryTerms, invertedIndex, queryExpansion=False):
 
   if queryExpansion:
     for queryTerm in stemmedQueryTerms:
-      expandedList += [term for chiSquare, term in queryExpansion(queryTerm, invertedIndex)]
+      expandedList += [term for chiSquare, term in performQueryExpansion(queryTerm, invertedIndex)]
   
   termDBObjects = []
   for term in expandedList:

--- a/ranker/loadInvertedIndexToMemory.py
+++ b/ranker/loadInvertedIndexToMemory.py
@@ -7,22 +7,6 @@ from mongoengine import *
 from mongoConfig import *
 from helpers import log
 
-
-# def loadInvertedIndexToMemory():
-#   log('info', 'Loading Inverted Index into main memory.')
-#   startTime=time.time()
-
-#   invertedIndex = InvertedIndex.objects()
-#   allTerms = [(term['doc_info'], term['term']) for term in invertedIndex]
-  
-#   termReverseMap = {}
-#   for i in range(0, len(allTerms)):
-#     termReverseMap[allTerms[i][1]] = i
-
-#   log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
-#   return termReverseMap, invertedIndex
-
-# ----------------------- END OF OLD LOAD INVERTED INDEX ------------------------
 def loadInvertedIndexToMemory():
   log('info', 'Loading Inverted Index into main memory.')
   startTime=time.time()

--- a/ranker/loadInvertedIndexToMemory.py
+++ b/ranker/loadInvertedIndexToMemory.py
@@ -57,7 +57,7 @@ def loadInvertedIndexToMemory():
       try:
         inMemoryTFIDF[termNum][crawlerAxisPos] = doc['tfidf']
       except:
-        inMemoryTFIDF[termNum][crawlerAxisPos] = 0.001
+        inMemoryTFIDF[termNum][crawlerAxisPos] = 0.0001
 
   log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
   return inMemoryTFIDF, invertedIndex, crawlerReverseMap, termReverseMap, pageRanks, authority

--- a/ranker/loadInvertedIndexToMemory.py
+++ b/ranker/loadInvertedIndexToMemory.py
@@ -8,6 +8,21 @@ from mongoConfig import *
 from helpers import log
 
 
+# def loadInvertedIndexToMemory():
+#   log('info', 'Loading Inverted Index into main memory.')
+#   startTime=time.time()
+
+#   invertedIndex = InvertedIndex.objects()
+#   allTerms = [(term['doc_info'], term['term']) for term in invertedIndex]
+  
+#   termReverseMap = {}
+#   for i in range(0, len(allTerms)):
+#     termReverseMap[allTerms[i][1]] = i
+
+#   log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
+#   return termReverseMap, invertedIndex
+
+# ----------------------- END OF OLD LOAD INVERTED INDEX ------------------------
 def loadInvertedIndexToMemory():
   log('info', 'Loading Inverted Index into main memory.')
   startTime=time.time()
@@ -15,9 +30,34 @@ def loadInvertedIndexToMemory():
   invertedIndex = InvertedIndex.objects()
   allTerms = [(term['doc_info'], term['term']) for term in invertedIndex]
   
+  documents = []
+  pageRanks = []
+  authority = []
+  for document in Crawler.objects():
+    documents.append(document['url'])
+    pageRanks.append(document['pageRank'])
+    authority.append(document['authority'])
+
+  inMemoryTFIDF= np.zeros((InvertedIndex.objects.count(), Crawler.objects.count()))
+
+  crawlerReverseMap = {}
+  for i in range(0, len(documents)):
+    crawlerReverseMap[documents[i]] = i
+
   termReverseMap = {}
-  for i in range(0, len(allTerms)):
+  for i in range(0, len(invertedIndex)):
     termReverseMap[allTerms[i][1]] = i
 
+  for termEntry in allTerms:
+    termNum = termReverseMap[termEntry[1]]
+    for docKey in termEntry[0]:
+      doc = termEntry[0][docKey]
+      url=doc['url']
+      crawlerAxisPos = crawlerReverseMap[url]
+      try:
+        inMemoryTFIDF[termNum][crawlerAxisPos] = doc['tfidf']
+      except:
+        inMemoryTFIDF[termNum][crawlerAxisPos] = 0.001
+
   log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
-  return termReverseMap, invertedIndex
+  return inMemoryTFIDF, invertedIndex, crawlerReverseMap, termReverseMap, pageRanks, authority

--- a/ranker/pseudoRelevanceFeedback.py
+++ b/ranker/pseudoRelevanceFeedback.py
@@ -60,7 +60,6 @@ def performPseudoRelevanceFeedback(queryMatrix, rankedDocuments, invertedIndex, 
   docURLs = set()
   newQueryForCalculation = np.array(queryMatrix, copy=True)
 
-  ###Fetch documents and perform cosine similarity  
   for termInfo in sortedTermWeightings:
     newQueryForCalculation[termInfo[1]] += 1
     term = invertedIndex[termInfo[1]]

--- a/ranker/pseudoRelevanceFeedback.py
+++ b/ranker/pseudoRelevanceFeedback.py
@@ -5,6 +5,8 @@ sys.path.append('..')
 sys.path.append('../crawler')
 from helpers import log
 from mongoConfig import *
+import numpy as np
+import rankerDBConfig
 
 ##Try it with Rocchio first. If that's not good, then use KL-Divergence
 # Assume top N documents are relevant (maybe 10?), rest are non-relevant.
@@ -12,12 +14,36 @@ from mongoConfig import *
 #Terms with 0 or negative weights in query are dropped.
 #Use new top N ranked words for new query (50?)
 #Alpha = 8, Beta = 16, Gamma = 4
-def performPseudoRelevanceFeedback():
+
+#Bring back in memory TFIDF otherwise fuck this cuz it'll take too long
+
+#Run this after running rankDocuments, can't test this without doing that.
+ALPHA = 8
+BETA = 16
+GAMMA = 4
+NUM_RELEVANT = 10
+MAX_WORDS = 50
+
+def performPseudoRelevanceFeedback(queryMatrix, rankedDocuments, invertedIndex, termReverseMap):
   startTime = time.time()
   log('pseudo-relevance', 'Performing Pseudo-Relevance Feedback')
 
   log('time', 'Finished performing Pseudo-Relevance Feedback in ' + str(time.time() - startTime) + ' seconds')
 
 if __name__ == '__main__':
+  from nltk.stem import PorterStemmer 
+  from loadInvertedIndexToMemory import loadInvertedIndexToMemory
+
+  termReverseMap, invertedIndex = loadInvertedIndexToMemory()
+
+  porterStemmer = PorterStemmer()
   connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
-  performPseudoRelevanceFeedback()
+  rawQuery = 'spicy chipotle burrito'.split()
+  stemmedTerms = []
+  for term in rawQuery:
+    stemmedTerms.append(porterStemmer.stem(term))
+
+  queryMatrix = np.zeros(InvertedIndex.objects.count())
+  for term in stemmedTerms:
+    queryMatrix[termReverseMap[term]] += 1
+  performPseudoRelevanceFeedback(queryMatrix, invertedIndex, termReverseMap)

--- a/ranker/pseudoRelevanceFeedback.py
+++ b/ranker/pseudoRelevanceFeedback.py
@@ -22,7 +22,7 @@ ALPHA = 8
 BETA = 16.0
 GAMMA = 4.0
 NUM_RELEVANT = 10
-MAX_WORDS = 50
+MAX_NEW_WORDS = 50
 
 def performPseudoRelevanceFeedback(queryMatrix, rankedDocuments, invertedIndex, termReverseMap, inMemoryTFIDF, crawlerReverseMap):
   startTime = time.time()
@@ -39,7 +39,6 @@ def performPseudoRelevanceFeedback(queryMatrix, rankedDocuments, invertedIndex, 
   
   relevantMultiplier = float(BETA / NUM_RELEVANT)
   relevantWeights = relevantWeights * relevantMultiplier
-  print("Relevant Weights:", relevantWeights)
 
   nonRelevantWeights = np.zeros(len(invertedIndex))
   for i in range(NUM_RELEVANT, len(rankedDocuments)):
@@ -54,26 +53,16 @@ def performPseudoRelevanceFeedback(queryMatrix, rankedDocuments, invertedIndex, 
   newQuery = np.add(newQuery, relevantWeights)
   newQuery = np.add(newQuery, nonRelevantWeights)
 
-  print("New Query:", newQuery)
   #TODO Calculate all the cosine similarities again and re-rank
+  #Add top ranked terms to the query, refetch, then re-rank
+  numberList = [i for i in range(0, len(invertedIndex))]
+  sortedTermWeightings = [(termWeight, numberList) for termWeight, numberList in sorted(zip(newQuery, numberList), reverse=True)][0:MAX_NEW_WORDS]
+
+  newQueryForCalculation = np.array(queryMatrix, copy=True)
+  for term in sortedTermWeightings:
+    newQueryForCalculation[numberList] += 1
+  
+  ###Fetch documents and perform cosine similarity
 
   log('time', 'Finished performing Pseudo-Relevance Feedback in ' + str(time.time() - startTime) + ' seconds')
   return newQuery
-
-if __name__ == '__main__':
-  from nltk.stem import PorterStemmer 
-  from loadInvertedIndexToMemory import loadInvertedIndexToMemory
-
-  termReverseMap, invertedIndex = loadInvertedIndexToMemory()
-
-  porterStemmer = PorterStemmer()
-  connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
-  rawQuery = 'spicy chipotle burrito'.split()
-  stemmedTerms = []
-  for term in rawQuery:
-    stemmedTerms.append(porterStemmer.stem(term))
-
-  queryMatrix = np.zeros(InvertedIndex.objects.count())
-  for term in stemmedTerms:
-    queryMatrix[termReverseMap[term]] += 1
-  performPseudoRelevanceFeedback(queryMatrix, invertedIndex, termReverseMap)

--- a/ranker/pseudoRelevanceFeedback.py
+++ b/ranker/pseudoRelevanceFeedback.py
@@ -19,16 +19,46 @@ import rankerDBConfig
 
 #Run this after running rankDocuments, can't test this without doing that.
 ALPHA = 8
-BETA = 16
-GAMMA = 4
+BETA = 16.0
+GAMMA = 4.0
 NUM_RELEVANT = 10
 MAX_WORDS = 50
 
-def performPseudoRelevanceFeedback(queryMatrix, rankedDocuments, invertedIndex, termReverseMap):
+def performPseudoRelevanceFeedback(queryMatrix, rankedDocuments, invertedIndex, termReverseMap, inMemoryTFIDF, crawlerReverseMap):
   startTime = time.time()
   log('pseudo-relevance', 'Performing Pseudo-Relevance Feedback')
+  newQuery = np.zeros(len(invertedIndex))
+  newQuery = queryMatrix * ALPHA
+
+  relevantWeights = np.zeros(len(invertedIndex))
+  for i in range(0, NUM_RELEVANT):
+    currentDoc = rankedDocuments[i]
+    docIndex = crawlerReverseMap[currentDoc]
+    docWeights = inMemoryTFIDF[:, docIndex]
+    relevantWeights = np.add(relevantWeights, docWeights)
+  
+  relevantMultiplier = float(BETA / NUM_RELEVANT)
+  relevantWeights = relevantWeights * relevantMultiplier
+  print("Relevant Weights:", relevantWeights)
+
+  nonRelevantWeights = np.zeros(len(invertedIndex))
+  for i in range(NUM_RELEVANT, len(rankedDocuments)):
+    currentDoc = rankedDocuments[i]
+    docIndex = crawlerReverseMap[currentDoc]
+    docWeights = inMemoryTFIDF[:, docIndex]
+    nonRelevantWeights = np.subtract(nonRelevantWeights, docWeights)
+  
+  nonRelevantMultiplier = float(GAMMA / (len(rankedDocuments) - NUM_RELEVANT))
+  nonRelevantWeights = nonRelevantWeights * nonRelevantMultiplier
+
+  newQuery = np.add(newQuery, relevantWeights)
+  newQuery = np.add(newQuery, nonRelevantWeights)
+
+  print("New Query:", newQuery)
+  #TODO Calculate all the cosine similarities again and re-rank
 
   log('time', 'Finished performing Pseudo-Relevance Feedback in ' + str(time.time() - startTime) + ' seconds')
+  return newQuery
 
 if __name__ == '__main__':
   from nltk.stem import PorterStemmer 

--- a/ranker/pseudoRelevanceFeedback.py
+++ b/ranker/pseudoRelevanceFeedback.py
@@ -1,0 +1,23 @@
+import math
+import sys
+import time
+sys.path.append('..')
+sys.path.append('../crawler')
+from helpers import log
+from mongoConfig import *
+
+##Try it with Rocchio first. If that's not good, then use KL-Divergence
+# Assume top N documents are relevant (maybe 10?), rest are non-relevant.
+##This will return a new query.
+#Terms with 0 or negative weights in query are dropped.
+#Use new top N ranked words for new query (50?)
+#Alpha = 8, Beta = 16, Gamma = 4
+def performPseudoRelevanceFeedback():
+  startTime = time.time()
+  log('pseudo-relevance', 'Performing Pseudo-Relevance Feedback')
+
+  log('time', 'Finished performing Pseudo-Relevance Feedback in ' + str(time.time() - startTime) + ' seconds')
+
+if __name__ == '__main__':
+  connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
+  performPseudoRelevanceFeedback()

--- a/ranker/queryExpansion.py
+++ b/ranker/queryExpansion.py
@@ -82,7 +82,7 @@ def threadedQueryExpansion(query, threads=1):
 
 #This stores the inverted index in memory for actually really fast calculation.
 #Should probably move forward with this method if we want to use it. Threading is wayyyy too slow.
-def queryExpansion(query, terms):
+def performQueryExpansion(query, terms):
   startTime = time.time()
   log("QE", 'Performing Query Expansion on ' + query)
 

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -59,7 +59,7 @@ def rank(queryTerms, termReverseMap, invertedIndex, inMemoryTFIDF, crawlerRevers
     #   else:
     #     tfidf = document['tfidf'][term]
     #     docWeights[termNum] += tfidf
-    
+
     docIndex = crawlerReverseMap[url]
     docWeights = inMemoryTFIDF[:,docIndex]
 
@@ -71,7 +71,7 @@ def rank(queryTerms, termReverseMap, invertedIndex, inMemoryTFIDF, crawlerRevers
   sortedDocUrls = [docUrl for ranking, docUrl in sorted(zip(rankings, docUrlArr), reverse=True)]
   
   if pseudoRelevanceFeedback:
-    performPseudoRelevanceFeedback(queryTermWeights, sortedDocUrls, invertedIndex, termReverseMap)
+    performPseudoRelevanceFeedback(queryTermWeights, sortedDocUrls, invertedIndex, termReverseMap, inMemoryTFIDF, crawlerReverseMap)
 
   log('time', 'Execution time for cosine similarities for ' + queryStr + ': ' +str(time.time()-startTime)+' seconds')
   return sortedDocUrls

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -12,7 +12,7 @@ from pseudoRelevanceFeedback import performPseudoRelevanceFeedback
 
 porterStemmer = PorterStemmer()
 
-def rank(queryTerms, termReverseMap, invertedIndex, queryExpansion=False, pseudoRelevanceFeedback=False):
+def rank(queryTerms, termReverseMap, invertedIndex, inMemoryTFIDF, crawlerReverseMap, queryExpansion=False, pseudoRelevanceFeedback=False):
   startTime = time.time()
 
   docURLs = set()
@@ -48,17 +48,20 @@ def rank(queryTerms, termReverseMap, invertedIndex, queryExpansion=False, pseudo
     if 'Page not found' in document['title']:
       continue
 
-    docWeights = np.zeros(len(termReverseMap))
-    for rawTerm in document['body'].lower().split():
-      term = porterStemmer.stem(rawTerm)
-      termNum = termReverseMap.get(term)
-      if(termNum == None):
-        continue
-      if 'tfidf' not in document or term not in document['tfidf']:
-        docWeights[termNum] += 0.0001
-      else:
-        tfidf = document['tfidf'][term]
-        docWeights[termNum] += tfidf
+    # docWeights = np.zeros(len(termReverseMap))
+    # for rawTerm in document['body'].lower().split():
+    #   term = porterStemmer.stem(rawTerm)
+    #   termNum = termReverseMap.get(term)
+    #   if(termNum == None):
+    #     continue
+    #   if 'tfidf' not in document or term not in document['tfidf']:
+    #     docWeights[termNum] += 0.0001
+    #   else:
+    #     tfidf = document['tfidf'][term]
+    #     docWeights[termNum] += tfidf
+    
+    docIndex = crawlerReverseMap[url]
+    docWeights = inMemoryTFIDF[:,docIndex]
 
     rankVal = (cosineSimilarity(queryTermWeights, docWeights) * 0.85) + (document['pageRank'] * 0.08) + (document['authority'] * 0.07)
 

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -39,7 +39,7 @@ def rank(queryTerms, termReverseMap, invertedIndex, inMemoryTFIDF, crawlerRevers
   docUrlArr = []
   rankings = []
 
-  log("Ranking", 'Calculating rankings for query')
+  log("Ranking", 'Calculating rankings for query: '+queryStr)
   for url in docURLs:
     try:
       document = Crawler.objects.get(url=url)

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -8,10 +8,11 @@ import time
 from cosineSimilarity import cosineSimilarity
 from fetchDocuments import fetchDocuments
 from nltk.stem import PorterStemmer 
+from pseudoRelevanceFeedback import performPseudoRelevanceFeedback
 
 porterStemmer = PorterStemmer()
 
-def rank(queryTerms, termReverseMap, invertedIndex):
+def rank(queryTerms, termReverseMap, invertedIndex, queryExpansion=False, pseudoRelevanceFeedback=False):
   startTime = time.time()
 
   docURLs = set()
@@ -21,7 +22,7 @@ def rank(queryTerms, termReverseMap, invertedIndex):
     queryStr+=term + ' '
   
   log("QE", 'Expanding Query Terms')
-  expandedTerms = fetchDocuments(queryTerms, invertedIndex)
+  expandedTerms = fetchDocuments(queryTerms, invertedIndex, queryExpansion=queryExpansion)
   for termEntry in expandedTerms:
     docInfoList=termEntry['doc_info']
     for docKey in docInfoList:
@@ -65,6 +66,9 @@ def rank(queryTerms, termReverseMap, invertedIndex):
     docUrlArr.append(url)
 
   sortedDocUrls = [docUrl for ranking, docUrl in sorted(zip(rankings, docUrlArr), reverse=True)]
+  
+  if pseudoRelevanceFeedback:
+    performPseudoRelevanceFeedback(queryTermWeights, sortedDocUrls, invertedIndex, termReverseMap)
 
   log('time', 'Execution time for cosine similarities for ' + queryStr + ': ' +str(time.time()-startTime)+' seconds')
   return sortedDocUrls

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -48,18 +48,6 @@ def rank(queryTerms, termReverseMap, invertedIndex, inMemoryTFIDF, crawlerRevers
     if 'Page not found' in document['title']:
       continue
 
-    # docWeights = np.zeros(len(termReverseMap))
-    # for rawTerm in document['body'].lower().split():
-    #   term = porterStemmer.stem(rawTerm)
-    #   termNum = termReverseMap.get(term)
-    #   if(termNum == None):
-    #     continue
-    #   if 'tfidf' not in document or term not in document['tfidf']:
-    #     docWeights[termNum] += 0.0001
-    #   else:
-    #     tfidf = document['tfidf'][term]
-    #     docWeights[termNum] += tfidf
-
     docIndex = crawlerReverseMap[url]
     docWeights = inMemoryTFIDF[:,docIndex]
 
@@ -71,7 +59,7 @@ def rank(queryTerms, termReverseMap, invertedIndex, inMemoryTFIDF, crawlerRevers
   sortedDocUrls = [docUrl for ranking, docUrl in sorted(zip(rankings, docUrlArr), reverse=True)]
   
   if pseudoRelevanceFeedback:
-    performPseudoRelevanceFeedback(queryTermWeights, sortedDocUrls, invertedIndex, termReverseMap, inMemoryTFIDF, crawlerReverseMap)
+    sortedDocUrls = performPseudoRelevanceFeedback(queryTermWeights, sortedDocUrls, invertedIndex, termReverseMap, inMemoryTFIDF, crawlerReverseMap)
 
   log('time', 'Execution time for cosine similarities for ' + queryStr + ': ' +str(time.time()-startTime)+' seconds')
   return sortedDocUrls

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -37,6 +37,9 @@ connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=2701
 termReverseMap, invertedIndex = loadInvertedIndexToMemory()
 stopwords = set(nltk.corpus.stopwords.words('english'))
 
+QUERY_EXPANSION = True
+PSEUDO_RELEVANCE_FEEDBACK = True
+
 @app.route('/', methods=["GET"])
 def index():
   return 'I am the ranker!'
@@ -45,7 +48,7 @@ def index():
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   queryTerms = stemQuery(query, stopwords)
-  sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex)
+  sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex, queryExpansion=QUERY_EXPANSION, pseudoRelevanceFeedback=PSEUDO_RELEVANCE_FEEDBACK)
   log("Ranked", 'Ranked '+str(len(sortedDocUrls)) +' documents.')
   return sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls[0:200]})
 

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -34,10 +34,10 @@ app = Flask(__name__)
 port = 80 if app.config['ENV']=='production' else 8002
 connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=27017)
 
-termReverseMap, invertedIndex = loadInvertedIndexToMemory()
+inMemoryTFIDF, invertedIndex, crawlerReverseMap, termReverseMap, pageRanks, authority = loadInvertedIndexToMemory()
 stopwords = set(nltk.corpus.stopwords.words('english'))
 
-QUERY_EXPANSION = True
+QUERY_EXPANSION = False
 PSEUDO_RELEVANCE_FEEDBACK = True
 
 @app.route('/', methods=["GET"])
@@ -47,8 +47,9 @@ def index():
 @app.route('/query/<query>', methods=['GET'])
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
+
   queryTerms = stemQuery(query, stopwords)
-  sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex, queryExpansion=QUERY_EXPANSION, pseudoRelevanceFeedback=PSEUDO_RELEVANCE_FEEDBACK)
+  sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex, inMemoryTFIDF, crawlerReverseMap, queryExpansion=QUERY_EXPANSION, pseudoRelevanceFeedback=PSEUDO_RELEVANCE_FEEDBACK)
   log("Ranked", 'Ranked '+str(len(sortedDocUrls)) +' documents.')
   return sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls[0:200]})
 

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -37,7 +37,7 @@ connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=2701
 inMemoryTFIDF, invertedIndex, crawlerReverseMap, termReverseMap, pageRanks, authority = loadInvertedIndexToMemory()
 stopwords = set(nltk.corpus.stopwords.words('english'))
 
-QUERY_EXPANSION = False
+QUERY_EXPANSION = True
 PSEUDO_RELEVANCE_FEEDBACK = True
 
 @app.route('/', methods=["GET"])


### PR DESCRIPTION
**Updates**
1. Performs Pseudo-Relevance Feedback to find new query Terms, original query terms still has double weightage
2. Fix bug small bug in calculateTFIDF
3. Bring back inMemoryTFIDF for faster rankings

**Testing Plan**
Look at search results, it should look better. Additionally, ranker should not crash or throw any error messages when performing Pseudo-Rel
