### PR TITLE
Excluded terms working with colon method

### DIFF
--- a/ranker/loadInvertedIndexToMemory.py
+++ b/ranker/loadInvertedIndexToMemory.py
@@ -32,6 +32,7 @@ def loadInvertedIndexToMemory():
   for i in range(0, len(invertedIndex)):
     termReverseMap[allTerms[i][1]] = i
 
+  ###UPDATE THIS BACK TO OLD WAY OF GETTING TFIDF
   for termEntry in allTerms:
     termNum = termReverseMap[termEntry[1]]
     for docKey in termEntry[0]:
@@ -41,7 +42,7 @@ def loadInvertedIndexToMemory():
       try:
         inMemoryTFIDF[termNum][crawlerAxisPos] = doc['tfidf']
       except:
-        inMemoryTFIDF[termNum][crawlerAxisPos] = 0.0001
+        inMemoryTFIDF[termNum][crawlerAxisPos] = 0.001
 
   log('time', 'Finished loading Inverted Index into main memory in ' + str(time.time()-startTime) + ' seconds.')
   return inMemoryTFIDF, invertedIndex, crawlerReverseMap, termReverseMap, pageRanks, authority

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -42,7 +42,6 @@ def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
 
   log("Ranking", 'Calculating rankings for query')
 
-  #Different
   excludedIndexes = []
   for term in excludedTerms:
     try:
@@ -50,8 +49,6 @@ def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
       excludedIndexes.append(excludedIndex)
     except:
       continue
-  #end of differences
-
 
   for url in docURLs:
     try:
@@ -61,8 +58,6 @@ def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
     if 'Page not found' in document['title']:
       continue
 
-
-    #Code is different starting from here
     docIndex = crawlerReverseMap[url]
     docWeights = inMemoryTFIDF[:,docIndex]
 
@@ -74,29 +69,7 @@ def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
     if containsExcludedTerm:
       containsExcludedTerm = False
       continue
-    # docWeights = np.zeros(len(termReverseMap))
-    # for rawTerm in document['body'].lower().split():
-    #   term = porterStemmer.stem(rawTerm)
-    #   if term in excludedTerms: 
-    #      containsExcludedTerm = True
-    #      break
-    #   termNum = termReverseMap.get(term)
 
-    #   if(termNum == None):
-    #     continue
-
-    #   if 'tfidf' not in document or term not in document['tfidf']:
-    #     docWeights[termNum] += 0.0001
-
-    #   else:
-    #     tfidf = document['tfidf'][term]
-    #     docWeights[termNum] += tfidf
-
-    # if containsExcludedTerm:
-    #   containsExcludedTerm = False
-    #   continue
-
-    #End of code differences
     rankVal = (cosineSimilarity(queryTermWeights, docWeights) * 0.85) + (document['pageRank'] * 0.08) + (document['authority'] * 0.07)
     rankings.append(rankVal)
     docUrlArr.append(url)

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -14,7 +14,7 @@ porterStemmer = PorterStemmer()
 def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
   startTime = time.time()
 
-  flag = False
+  containsExcludedTerm = False
 
   docURLs = set()
   queryTermWeights = np.zeros(len(termReverseMap))
@@ -53,23 +53,27 @@ def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
     for rawTerm in document['body'].lower().split():
       term = porterStemmer.stem(rawTerm)
       if term in excludedTerms: 
-         flag = True
+         containsExcludedTerm = True
          break
       termNum = termReverseMap.get(term)
+
       if(termNum == None):
         continue
+
       if 'tfidf' not in document or term not in document['tfidf']:
         docWeights[termNum] += 0.0001
+
       else:
         tfidf = document['tfidf'][term]
         docWeights[termNum] += tfidf
 
-    if flag != True:
-      rankVal = (cosineSimilarity(queryTermWeights, docWeights) * 0.85) + (document['pageRank'] * 0.08) + (document['authority'] * 0.07)
-      rankings.append(rankVal)
-      docUrlArr.append(url)
-    else: 
-      flag = False
+    if containsExcludedTerm:
+      containsExcludedTerm = False
+      continue
+
+    rankVal = (cosineSimilarity(queryTermWeights, docWeights) * 0.85) + (document['pageRank'] * 0.08) + (document['authority'] * 0.07)
+    rankings.append(rankVal)
+    docUrlArr.append(url)
 
   sortedDocUrls = [docUrl for ranking, docUrl in sorted(zip(rankings, docUrlArr), reverse=True)]
 

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -54,6 +54,7 @@ def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
       term = porterStemmer.stem(rawTerm)
       if term in excludedTerms: 
          flag = True
+         break
       termNum = termReverseMap.get(term)
       if(termNum == None):
         continue
@@ -63,9 +64,8 @@ def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
         tfidf = document['tfidf'][term]
         docWeights[termNum] += tfidf
 
-    rankVal = (cosineSimilarity(queryTermWeights, docWeights) * 0.85) + (document['pageRank'] * 0.08) + (document['authority'] * 0.07)
-
     if flag != True:
+      rankVal = (cosineSimilarity(queryTermWeights, docWeights) * 0.85) + (document['pageRank'] * 0.08) + (document['authority'] * 0.07)
       rankings.append(rankVal)
       docUrlArr.append(url)
     else: 

--- a/ranker/rankDocuments.py
+++ b/ranker/rankDocuments.py
@@ -11,8 +11,10 @@ from nltk.stem import PorterStemmer
 
 porterStemmer = PorterStemmer()
 
-def rank(queryTerms, termReverseMap, invertedIndex):
+def rank(queryTerms, termReverseMap, invertedIndex, excludedTerms):
   startTime = time.time()
+
+  flag = False
 
   docURLs = set()
   queryTermWeights = np.zeros(len(termReverseMap))
@@ -50,6 +52,8 @@ def rank(queryTerms, termReverseMap, invertedIndex):
     docWeights = np.zeros(len(termReverseMap))
     for rawTerm in document['body'].lower().split():
       term = porterStemmer.stem(rawTerm)
+      if term in excludedTerms: 
+         flag = True
       termNum = termReverseMap.get(term)
       if(termNum == None):
         continue
@@ -61,8 +65,11 @@ def rank(queryTerms, termReverseMap, invertedIndex):
 
     rankVal = (cosineSimilarity(queryTermWeights, docWeights) * 0.85) + (document['pageRank'] * 0.08) + (document['authority'] * 0.07)
 
-    rankings.append(rankVal)
-    docUrlArr.append(url)
+    if flag != True:
+      rankings.append(rankVal)
+      docUrlArr.append(url)
+    else: 
+      flag = False
 
   sortedDocUrls = [docUrl for ranking, docUrl in sorted(zip(rankings, docUrlArr), reverse=True)]
 

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -45,15 +45,15 @@ def index():
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   index = query.find(":")
-  newStr = str(index)
-  if index != -1: 
-    excludedTermsQuery = query[index+1:len(query)]
-    query = query[0:index]
-    excludedTerms = stemQuery(excludedTermsQuery, stopwords)
-  else: 
+  if index == -1: 
     excludedTerms = []
-
-  queryTerms = stemQuery(query, stopwords)
+    pureQuery = query
+  else:
+    excludedTerms = stemQuery(query[index+1:len(query)], stopwords)
+    pureQuery = query[0:index]
+    
+  print("Excluded terms:", excludedTerms)
+  queryTerms = stemQuery(pureQuery, stopwords)
   sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex, excludedTerms)
   log("Ranked", 'Ranked '+str(len(sortedDocUrls)) +' documents.')
   return sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls[0:200]})

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -37,8 +37,8 @@ connect(rankerDBConfig.databaseName, host=rankerDBConfig.databaseAddr, port=2701
 inMemoryTFIDF, invertedIndex, crawlerReverseMap, termReverseMap, pageRanks, authority = loadInvertedIndexToMemory()
 stopwords = set(nltk.corpus.stopwords.words('english'))
 
-QUERY_EXPANSION = True
-PSEUDO_RELEVANCE_FEEDBACK = True
+QUERY_EXPANSION = False
+PSEUDO_RELEVANCE_FEEDBACK = False
 
 @app.route('/', methods=["GET"])
 def index():

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -44,8 +44,17 @@ def index():
 @app.route('/query/<query>', methods=['GET'])
 def rankQuery(query):
   log('Ranker', 'Received query: '+query)
+  index = query.find(":")
+  newStr = str(index)
+  log('Ranker', 'Number: '+ newStr)
+  if index != -1: 
+    excludedTerms = query[index+1:len(query)]
+    excludedTerms.split(" ")
+  else: 
+    excludedTerms = []
+
   queryTerms = stemQuery(query, stopwords)
-  sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex)
+  sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex, excludedTerms)
   log("Ranked", 'Ranked '+str(len(sortedDocUrls)) +' documents.')
   return sendPacket(1, 'Successfully retrieved query', {'sortedDocUrls':sortedDocUrls[0:200]})
 

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -52,7 +52,6 @@ def rankQuery(query):
     excludedTerms = stemQuery(query[index+1:len(query)], stopwords)
     pureQuery = query[0:index]
     
-  print("Excluded terms:", excludedTerms)
   queryTerms = stemQuery(pureQuery, stopwords)
   sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex, excludedTerms)
   log("Ranked", 'Ranked '+str(len(sortedDocUrls)) +' documents.')

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -47,10 +47,11 @@ def rankQuery(query):
   index = query.find(":")
   newStr = str(index)
   if index != -1: 
-    excludedTerms = query[index+1:len(query)]
-    excludedTerms.split(" ")
+    excludedTermsQuery = query[index+1:len(query)]
+    query = query[0:index]
+    excludedTerms = stemQuery(excludedTermsQuery, stopwords)
   else: 
-    excludedTerms = []
+    excludedTermsQuery = []
 
   queryTerms = stemQuery(query, stopwords)
   sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex, excludedTerms)

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -46,7 +46,6 @@ def rankQuery(query):
   log('Ranker', 'Received query: '+query)
   index = query.find(":")
   newStr = str(index)
-  log('Ranker', 'Number: '+ newStr)
   if index != -1: 
     excludedTerms = query[index+1:len(query)]
     excludedTerms.split(" ")

--- a/ranker/ranker.py
+++ b/ranker/ranker.py
@@ -51,7 +51,7 @@ def rankQuery(query):
     query = query[0:index]
     excludedTerms = stemQuery(excludedTermsQuery, stopwords)
   else: 
-    excludedTermsQuery = []
+    excludedTerms = []
 
   queryTerms = stemQuery(query, stopwords)
   sortedDocUrls = rank(queryTerms, termReverseMap, invertedIndex, excludedTerms)


### PR DESCRIPTION
Anything in the query after the colon will now be excluded when calculating the rankings and presenting the results. 
Example: Lettuce : avocado will show all results that have recipes including lettuce but not avocado. 
